### PR TITLE
Disable notFound logging when in test environment

### DIFF
--- a/packages/i18n-jsx/src/utils/handleNotFound.ts
+++ b/packages/i18n-jsx/src/utils/handleNotFound.ts
@@ -1,5 +1,5 @@
 const handleNotFound = (k: string | number, notFound: string) => {
-  if (process.env.NODE_ENV !== 'production') {
+  if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
     console.warn(`[i18n-jsx]: '${k}' key was not found in the translations object, falling back to notFound value.`)
   }
 

--- a/packages/i18n-jsx/tests/handleNotFound.test.ts
+++ b/packages/i18n-jsx/tests/handleNotFound.test.ts
@@ -2,7 +2,7 @@ import 'jest'
 
 const consoleWarn = jest.spyOn(global.console, 'warn').mockImplementation(() => {})
 
-import handleNotFound from '../src/utils/handleNotFound';
+import handleNotFound from '../src/utils/handleNotFound'
 
 describe('handleNotFound()', () => {
   const OLD_ENV = process.env
@@ -14,26 +14,34 @@ describe('handleNotFound()', () => {
   })
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.clearAllMocks()
     process.env = OLD_ENV
   })
 
   it('should print console warning when node env is not production', () => {
-    process.env.NODE_ENV = 'dev';
+    process.env.NODE_ENV = 'dev'
 
-    handleNotFound(1, 'not found message');
-    
-    expect(consoleWarn).toHaveBeenCalledTimes(1);
-    expect(consoleWarn).toHaveBeenCalledWith('[i18n-jsx]: \'1\' key was not found in the translations object, falling back to notFound value.')
+    handleNotFound(1, 'not found message')
 
+    expect(consoleWarn).toHaveBeenCalledTimes(1)
+    expect(consoleWarn).toHaveBeenCalledWith(
+      "[i18n-jsx]: '1' key was not found in the translations object, falling back to notFound value."
+    )
   })
 
   it('should not print console warning when node env is production', () => {
-    process.env.NODE_ENV = 'production';
+    process.env.NODE_ENV = 'production'
 
-    handleNotFound(1, 'not found message');
-    
-    expect(consoleWarn).toHaveBeenCalledTimes(0);
+    handleNotFound(1, 'not found message')
 
+    expect(consoleWarn).toHaveBeenCalledTimes(0)
+  })
+
+  it('should not print console warning when node env is test', () => {
+    process.env.NODE_ENV = 'test'
+
+    handleNotFound(1, 'not found message')
+
+    expect(consoleWarn).toHaveBeenCalledTimes(0)
   })
 })


### PR DESCRIPTION
When `test` node env is found, the `[i18n-jsx]: '${k}' key was not found in the translations object, falling back to notFound value.` message warning is no longer printed to the console.