### PR TITLE
fix(format-to-jsx): shouldnt format when no args were passed

### DIFF
--- a/packages/format-to-jsx/src/format/index.tsx
+++ b/packages/format-to-jsx/src/format/index.tsx
@@ -8,6 +8,7 @@ const format = <TArgs extends FArgs>(
   if (!template || template.length === 0) {
     throw new Error(`[format-to-jsx]: format() method has been called without a template string!`)
   }
+  if (args.length === 0) return template as any
   const reg = /\{([^{}]+)\}/g
   let containsJSX = false
   const argsDictionary =

--- a/packages/format-to-jsx/tests/format.test.tsx
+++ b/packages/format-to-jsx/tests/format.test.tsx
@@ -34,6 +34,10 @@ describe('format()', () => {
     expect(() => format('')).toThrow('[format-to-jsx]: format() method has been called without a template string!')
   })
 
+  it('should not format when no args are passed', () => {
+    expect(format('simple non template with {placeholder}')).toBe('simple non template with {placeholder}')
+  })
+
   it('should not format non-template strings', () => {
     expect(format('simple non template')).toBe('simple non template')
   })


### PR DESCRIPTION
Formatting function will no longer try to format templates when no arguments were passed to it.

fix #17