### PR TITLE
fix(i18n-jsx): fix formatting without params

### DIFF
--- a/packages/i18n-jsx/package.json
+++ b/packages/i18n-jsx/package.json
@@ -16,7 +16,7 @@
     "react": "16.8.6"
   },
   "dependencies": {
-    "format-to-jsx": "1.0.0"
+    "format-to-jsx": "^1.0.1"
   },
   "devDependencies": {
     "@testing-library/react": "8.0.1",

--- a/packages/i18n-jsx/tests/I18n.test.tsx
+++ b/packages/i18n-jsx/tests/I18n.test.tsx
@@ -21,6 +21,19 @@ describe('<I18n />', () => {
     cleanup()
     jest.clearAllMocks()
   })
+
+  it('should render not formatted text when no args were passed', () => {
+    const { container } = render(
+      <I18nProvider translations={translationsMock}>
+        <span>
+          <I18n k="example.template">{`string with {0} placeholder`}</I18n>
+        </span>
+      </I18nProvider>
+    )
+
+    expect(container.textContent).toEqual('string with {0} placeholder')
+  })
+
   it('should render text based on a numeric k prop', () => {
     const { container } = render(
       <I18nProvider translations={translationsMock}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6258,10 +6258,10 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-format-to-jsx@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/format-to-jsx/-/format-to-jsx-1.0.0.tgz#3fbba624495a7cd894f3b9c2c7ebd5adff2540f7"
-  integrity sha512-vGJ56akuarXpXw2Bq++inkzo1td1WTnVSw9R/IY6P6k3eZlv2KA/+GyVVA2HxP6AM2ux4DlK52AsQ4CckamHyA==
+format-to-jsx@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/format-to-jsx/-/format-to-jsx-1.0.1.tgz#f7e16d77ae4661dd44554bc2f275e5cb3e2df071"
+  integrity sha512-o6wnNlZi1QnfKDIgSdyTFbx/cjWIddNdjAG56V2zSLfeUJM+9vD1PaKYwO+dbgMFvqf1oC9caLHkt88grp/zyA==
 
 forwarded@~0.1.2:
   version "0.1.2"


### PR DESCRIPTION
We need to update to latest version of format-to-jsx to fix formatting when no params are provided

re #17