### PR TITLE
feat(feature-toggle-jsx): add validation selector to the withFeature component

### DIFF
--- a/packages/feature-toggle-jsx/src/withFeature/withFeature.tsx
+++ b/packages/feature-toggle-jsx/src/withFeature/withFeature.tsx
@@ -2,19 +2,27 @@ import * as React from 'react'
 import useFeatures from '../useFeatures/useFeatures'
 import { nameOf } from '../react-utils'
 import { FeatureSchema } from '../FeaturesContext/FeaturesContext'
-
 // Need this to land in TypeScript first for better type inference
 // Link: https://github.com/Microsoft/TypeScript/issues/26242
+
 const withFeature = <T, TComponentProps = {}, K extends keyof FeatureSchema<T> = keyof FeatureSchema<T>>(
   Component: React.ComponentType<TComponentProps>,
-  name: K
+  name: K,
+  isValidFeatureDetail: (feature: Exclude<FeatureSchema<T>[K], undefined | {}>) => boolean = () => true
 ) => {
   type OwnProps = Omit<TComponentProps, K>
 
   const Wrapped: React.FC<OwnProps> = React.memo(props => {
     const [feature] = useFeatures<T, K>(name)
+
+    if (!feature) {
+      return null
+    }
+    type featureType = Exclude<FeatureSchema<T>[K], undefined | {}>
+    const featureDetail = feature as featureType
+    const isValid = featureDetail && isValidFeatureDetail(featureDetail)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return feature ? <Component {...(props as any)} {...{ [name]: feature }} /> : null
+    return isValid ? <Component {...(props as any)} {...{ [name]: feature }} /> : null
   })
 
   Wrapped.displayName = `withFeature[${name}](${nameOf(Component)})`

--- a/packages/feature-toggle-jsx/tests/withFeature.test.tsx
+++ b/packages/feature-toggle-jsx/tests/withFeature.test.tsx
@@ -53,6 +53,68 @@ describe('withFeature()', () => {
     expect(container.textContent).toContain(configText(features.featureWithConfig!.items))
   })
 
+  it('render component with valid feature detail', () => {
+    interface Props {
+      featureWithConfig: FeatureWithConfig
+      text: string
+    }
+    const NeedConfigComponent: React.FC<Props> = props => {
+      const { text, featureWithConfig } = props
+      return (
+        <div>
+          {text} {configText(featureWithConfig.items)}
+        </div>
+      )
+    }
+
+    const Wrapped = withFeature<Features, Props>(
+      NeedConfigComponent,
+      'featureWithConfig',
+      (feature: FeatureWithConfig) => {
+        return feature.items.length > 1
+      }
+    )
+
+    const { container } = render(
+      <FeatureProvider features={features}>
+        <Wrapped text={componentText} />
+      </FeatureProvider>
+    )
+
+    expect(container.textContent).toContain(componentText)
+  })
+
+  it('not render component with invalid feature detail', () => {
+    interface Props {
+      featureWithConfig: FeatureWithConfig
+      text: string
+    }
+    const NeedConfigComponent: React.FC<Props> = props => {
+      const { text, featureWithConfig } = props
+      return (
+        <div>
+          {text} {configText(featureWithConfig.items)}
+        </div>
+      )
+    }
+
+    const Wrapped = withFeature<Features, Props>(
+      NeedConfigComponent,
+      'featureWithConfig',
+      (features: FeatureWithConfig) => {
+        return features.items.length == 0
+      }
+    )
+
+    const { container } = render(
+      <FeatureProvider features={features}>
+        <Wrapped text={componentText} />
+      </FeatureProvider>
+    )
+
+    expect(container.textContent).not.toContain(componentText)
+  })
+
   it('not render component when feature flag is disabled', () => {
     const Wrapped = withFeature<Features>(NoConfigComponent, 'disabledFeature')
 


### PR DESCRIPTION
Added option for passing feature level validation. If anyone doesn't rely only on `isEnabled:boolean`  can pass a function to `withFeature` as a third parameter.