### PR TITLE
fix(feature-toggle-jsx): making type of FeatureConfig more generic

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,9 +8,9 @@
       "type": "node",
       "request": "launch",
       "protocol": "inspector",
-      "name": "I18n-jsx: Debug Jest Test",
+      "name": "Debug Jest Test",
       "program": "${workspaceRoot}/node_modules/jest-cli/bin/jest.js",
-      "cwd": "${workspaceRoot}/packages/i18n-jsx",
+      "cwd": "${workspaceRoot}",
       "args": ["--runInBand", "${fileBasename}"],
       "sourceMaps": true,
       "console": "integratedTerminal"

--- a/packages/feature-toggle-jsx/src/FeaturesContext/featureConfig.ts
+++ b/packages/feature-toggle-jsx/src/FeaturesContext/featureConfig.ts
@@ -1,7 +1,2 @@
-export interface Feature {
-  isEnabled: boolean
-}
-
-export interface FeatureConfig {
-  [key: string]: Feature
-}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type FeatureConfig = Record<string, Record<string | number, any>>;

--- a/packages/feature-toggle-jsx/src/useFeature/useFeature.ts
+++ b/packages/feature-toggle-jsx/src/useFeature/useFeature.ts
@@ -13,12 +13,12 @@ const useFeature = <
   TFeatureName extends Extract<keyof TFeatureConfig, string | number>
 >(
   featureName: TFeatureName,
-  isEnabled: (feature: TFeatureConfig[TFeatureName]) => boolean = (_) => _.isEnabled
+  isEnabled: (feature: TFeatureConfig[TFeatureName]) => boolean = (_) => !!_
 ): [boolean, TFeatureConfig[TFeatureName]] => {
   const features = useFeatures<TFeatureConfig>();
 
   const feature = features[featureName];
-  if (!feature) return [false, { isEnabled: false } as TFeatureConfig[TFeatureName]];
+  if (!feature) return [false, {} as TFeatureConfig[TFeatureName]];
 
   return [
     isEnabled(feature),

--- a/packages/feature-toggle-jsx/src/withFeature/withFeature.tsx
+++ b/packages/feature-toggle-jsx/src/withFeature/withFeature.tsx
@@ -20,7 +20,7 @@ const withFeature = <
 >(
   Component: React.ComponentType<TOrigProps>,
   featureName: TFeatureName,
-  isEnabled: (feature: TFeatureConfig[TFeatureName]) => boolean = (_) => _.isEnabled
+  isEnabled: (feature: TFeatureConfig[TFeatureName]) => boolean = (_) => !!_
 ) => {
   const Wrapped: React.FC<TOrigProps> = React.memo((props) => {
     const [enabled] = useFeature(featureName, isEnabled);

--- a/packages/feature-toggle-jsx/src/withoutFeature/withoutFeature.tsx
+++ b/packages/feature-toggle-jsx/src/withoutFeature/withoutFeature.tsx
@@ -20,7 +20,7 @@ const withoutFeature = <
 >(
   Component: React.ComponentType<TOrigProps>,
   featureName: TFeatureName,
-  isEnabled: (feature: TFeatureConfig[TFeatureName]) => boolean = (_) => _.isEnabled
+  isEnabled: (feature: TFeatureConfig[TFeatureName]) => boolean = (_) => !!_
 ) => {
   const Wrapped: React.FC<TOrigProps> = React.memo((props) => {
     const [enabled] = useFeature(featureName, isEnabled);

--- a/packages/feature-toggle-jsx/tests/useFeature.test.tsx
+++ b/packages/feature-toggle-jsx/tests/useFeature.test.tsx
@@ -2,11 +2,13 @@ import * as React from 'react';
 import { render, cleanup } from '@testing-library/react';
 import * as FeatureToggleJsx from '../src/index';
 
-type CustomFeatureFields = {
-  someCustomField: boolean,
-}
 type CustomFeatureConfig = {
-  someFeat: FeatureToggleJsx.Feature & CustomFeatureFields
+  someFeat: {
+    someCustomField: number,
+  },
+  anotherFeat: {
+    itsOver: number
+  }
 }
 
 const {
@@ -20,13 +22,12 @@ describe('useFeature', () => {
     jest.clearAllMocks();
   });
 
-  it('should return isEnabled for specific feature from context', () => {
-    const featuresConfig: CustomFeatureConfig = {
+  it('should return isEnabled == true for specific feature from context that exists', () => {
+    const featuresConfig = {
       someFeat: {
-        isEnabled: true,
-        someCustomField: false
+        someCustomField: 10
       }
-    };
+    } as CustomFeatureConfig;
 
     const UnderTest: React.FC = () => {
       const [isEnabled] = useFeature('someFeat');
@@ -42,16 +43,36 @@ describe('useFeature', () => {
     expect(container.textContent).toEqual('someFeat=true');
   });
 
-  it('should return isEnabled for specific feature from context based on selector', () => {
-    const featuresConfig: CustomFeatureConfig = {
+  it('should return isEnabled == false for specific feature from context that doesnt exists', () => {
+    const featuresConfig = {
       someFeat: {
-        isEnabled: false,
-        someCustomField: true
+        someCustomField: 10
       }
-    };
+    } as CustomFeatureConfig;
 
     const UnderTest: React.FC = () => {
-      const [isEnabled] = useFeature('someFeat', (_) => _.someCustomField);
+      const [isEnabled] = useFeature('anotherFeat');
+      return <span>someFeat={`${isEnabled}`}</span>;
+    };
+
+    const { container } = render(
+      <FeaturesProvider features={featuresConfig}>
+        <UnderTest />
+      </FeaturesProvider>,
+    );
+
+    expect(container.textContent).toEqual('someFeat=false');
+  });
+
+  it('should return isEnabled == false for specific feature from context based on selector', () => {
+    const featuresConfig = {
+      someFeat: {
+        someCustomField: 10
+      }
+    } as CustomFeatureConfig;
+
+    const UnderTest: React.FC = () => {
+      const [isEnabled] = useFeature('someFeat', (_) => _.someCustomField === 10);
       return <span>someFeat={`${isEnabled}`}</span>;
     };
 
@@ -64,17 +85,16 @@ describe('useFeature', () => {
     expect(container.textContent).toEqual('someFeat=true');
   });
 
-  it('should return feature config for selected feature.', () => {
-    const featuresConfig: CustomFeatureConfig = {
+  it('should return isEnabled == false for specific feature from context based on selector when feature doesnt exits', () => {
+    const featuresConfig = {
       someFeat: {
-        isEnabled: false,
-        someCustomField: true
+        someCustomField: 10
       }
-    };
+    } as CustomFeatureConfig;
 
     const UnderTest: React.FC = () => {
-      const [enabled, config] = useFeature('someFeat', (_) => _.someCustomField);
-      return <span>{`enabled:${enabled},config.isEnabled:${config.isEnabled},config.someCustomField:${config.someCustomField}`}</span>;
+      const [isEnabled] = useFeature('anotherFeat', (_) => _.itsOver === 9000);
+      return <span>someFeat={`${isEnabled}`}</span>;
     };
 
     const { container } = render(
@@ -83,20 +103,40 @@ describe('useFeature', () => {
       </FeaturesProvider>,
     );
 
-    expect(container.textContent).toEqual('enabled:true,config.isEnabled:false,config.someCustomField:true');
+    expect(container.textContent).toEqual('someFeat=false');
+  });
+
+  it('should return feature config for selected feature.', () => {
+    const featuresConfig = {
+      someFeat: {
+        someCustomField: 10
+      }
+    } as CustomFeatureConfig;
+
+    const UnderTest: React.FC = () => {
+      const [enabled, config] = useFeature('someFeat', (_) => _.someCustomField === 10);
+      return <span>{`enabled:${enabled},config.someCustomField:${config.someCustomField}`}</span>;
+    };
+
+    const { container } = render(
+      <FeaturesProvider features={featuresConfig}>
+        <UnderTest />
+      </FeaturesProvider>,
+    );
+
+    expect(container.textContent).toEqual('enabled:true,config.someCustomField:10');
   });
 
   it('should enabled == false & default empty config for non-existing feature', () => {
     const featuresConfig = {
       someFeat: {
-        isEnabled: false,
-        someCustomField: true
+        someCustomField: 10
       }
-    };
+    } as CustomFeatureConfig;
 
     const UnderTest: React.FC = () => {
-      const [enabled, config] = useFeature('someFeat2' as keyof CustomFeatureConfig, (_) => _.someCustomField);
-      return <span>{`enabled:${enabled},config.isEnabled:${config.isEnabled},config.someCustomField:${config.someCustomField}`}</span>;
+      const [enabled, config] = useFeature('anotherFeat', (_) => _.itsOver > 9000);
+      return <span>{`enabled:${enabled},config.itsOver:${config.itsOver}`}</span>;
     };
 
     const { container } = render(
@@ -105,6 +145,6 @@ describe('useFeature', () => {
       </FeaturesProvider>,
     );
 
-    expect(container.textContent).toEqual('enabled:false,config.isEnabled:false,config.someCustomField:undefined');
+    expect(container.textContent).toEqual('enabled:false,config.itsOver:undefined');
   });
 });

--- a/packages/feature-toggle-jsx/tests/useFeatures.test.tsx
+++ b/packages/feature-toggle-jsx/tests/useFeatures.test.tsx
@@ -3,7 +3,12 @@ import { render, cleanup } from '@testing-library/react';
 import * as FeatureToggleJsx from '../src/index';
 
 type CustomFeatureConfig = {
-  someFeat: FeatureToggleJsx.Feature
+  someFeat: {
+    someCustomField: number,
+  },
+  anotherFeat: {
+    itsOver: number
+  }
 }
 
 const {
@@ -18,15 +23,15 @@ describe('useFeatures', () => {
   });
 
   it('should return isEnabled for specific feature from context', () => {
-    const featuresConfig: CustomFeatureConfig = {
+    const featuresConfig = {
       someFeat: {
-        isEnabled: true
+        someCustomField: 10
       }
-    };
+    } as CustomFeatureConfig;
 
     const UnderTest: React.FC = () => {
       const features = useFeatures();
-      return <span>someFeat={`${features.someFeat.isEnabled}`}</span>;
+      return <span>someFeat.someCustomField={`${features.someFeat.someCustomField}`}</span>;
     };
 
     const { container } = render(
@@ -35,6 +40,6 @@ describe('useFeatures', () => {
       </FeaturesProvider>,
     );
 
-    expect(container.textContent).toEqual('someFeat=true');
+    expect(container.textContent).toEqual('someFeat.someCustomField=10');
   });
 });

--- a/packages/feature-toggle-jsx/tests/withFeature.test.tsx
+++ b/packages/feature-toggle-jsx/tests/withFeature.test.tsx
@@ -2,13 +2,13 @@ import * as React from 'react';
 import { render, cleanup } from '@testing-library/react';
 import * as FeatureToggleJsx from '../src/index';
 
-type CustomFeatureFields = {
-  someCustomField: boolean,
-}
-
 type CustomFeatureConfig = {
-  feat1: FeatureToggleJsx.Feature & CustomFeatureFields
-  feat2: FeatureToggleJsx.Feature
+  someFeat: {
+    someCustomField: number,
+  },
+  anotherFeat: {
+    itsOver: number
+  }
 }
 
 const {
@@ -23,22 +23,18 @@ describe('withFeature', () => {
   });
 
   it('should only render wrapped component when feature is on', () => {
-    const featuresConfig: CustomFeatureConfig = {
-      feat1: {
-        isEnabled: true,
-        someCustomField: false
-      },
-      feat2: {
-        isEnabled: false
+    const featuresConfig = {
+      someFeat: {
+        someCustomField: 10
       }
-    };
+    } as CustomFeatureConfig;
 
     const App: React.FC = ({ children }) => <div>{children}</div>;
     const Feat1: React.FC = () => <span>This is feature 1</span>;
     const Feat2: React.FC = () => <span>This is feature 2</span>;
 
-    const WrappedFeat1 = withFeature(Feat1, 'feat1');
-    const WrappedFeat2 = withFeature(Feat2, 'feat2');
+    const WrappedFeat1 = withFeature(Feat1, 'someFeat');
+    const WrappedFeat2 = withFeature(Feat2, 'anotherFeat');
 
     const UnderTest: React.FC = () => (
       <><WrappedFeat1 /><WrappedFeat2 /></>
@@ -56,22 +52,18 @@ describe('withFeature', () => {
   });
 
   it('should enable using custom selector from feature config', () => {
-    const featuresConfig: CustomFeatureConfig = {
-      feat1: {
-        isEnabled: true,
-        someCustomField: true
-      },
-      feat2: {
-        isEnabled: false
+    const featuresConfig = {
+      someFeat: {
+        someCustomField: 10
       }
-    };
+    } as CustomFeatureConfig;
 
     const App: React.FC = ({ children }) => <div>{children}</div>;
     const Feat1: React.FC = () => <span>This is feature 1</span>;
     const Feat2: React.FC = () => <span>This is feature 2</span>;
 
-    const WrappedFeat1 = withFeature(Feat1, 'feat1', (_) => _.someCustomField);
-    const WrappedFeat2 = withFeature(Feat2, 'feat2');
+    const WrappedFeat1 = withFeature(Feat1, 'someFeat', (_) => _.someCustomField === 10);
+    const WrappedFeat2 = withFeature(Feat2, 'anotherFeat');
 
     const UnderTest: React.FC = () => (
       <><WrappedFeat1 /><WrappedFeat2 /></>

--- a/packages/feature-toggle-jsx/tests/withFeaturesProvider.test.tsx
+++ b/packages/feature-toggle-jsx/tests/withFeaturesProvider.test.tsx
@@ -2,8 +2,13 @@ import * as React from 'react';
 import { render, cleanup } from '@testing-library/react';
 import * as FeatureToggleJsx from '../src/index';
 
-interface CustomFeatureConfig extends FeatureToggleJsx.FeatureConfig {
-  customFlatFeature: FeatureToggleJsx.Feature
+type CustomFeatureConfig = {
+  someFeat: {
+    someCustomField: number,
+  },
+  anotherFeat: {
+    itsOver: number
+  }
 }
 
 const {
@@ -18,18 +23,18 @@ describe('withFeaturesProvider', () => {
   });
 
   it('should wrap component with context data when passing features as value', () => {
-    const featuresConfig: CustomFeatureConfig = {
-      customFlatFeature: {
-        isEnabled: true
+    const featuresConfig = {
+      someFeat: {
+        someCustomField: 10
       }
-    };
+    } as CustomFeatureConfig;
 
     const App: React.FC = ({ children }) => <div>{children}</div>;
 
     const UnderTest: React.FC = () => {
       const features = useFeatures();
       return (
-        <span>{`${features.customFlatFeature.isEnabled}`}</span>
+        <span>{`${features.someFeat.someCustomField}`}</span>
       );
     };
 
@@ -41,15 +46,16 @@ describe('withFeaturesProvider', () => {
       </WrappedApp>,
     );
 
-    expect(container.textContent).toEqual('true');
+    expect(container.textContent).toEqual('10');
   });
 
   it('should wrap component with context data when passing features as function', () => {
-    const featuresConfig: CustomFeatureConfig = {
-      customFlatFeature: {
-        isEnabled: true
+    const featuresConfig = {
+      someFeat: {
+        someCustomField: 10
       }
-    };
+    } as CustomFeatureConfig;
+
     type Props = {
       feats: CustomFeatureConfig
     }
@@ -58,7 +64,7 @@ describe('withFeaturesProvider', () => {
     const UnderTest: React.FC = () => {
       const features = useFeatures();
       return (
-        <span>{`${features.customFlatFeature.isEnabled}`}</span>
+        <span>{`${features.someFeat.someCustomField}`}</span>
       );
     };
 
@@ -71,6 +77,6 @@ describe('withFeaturesProvider', () => {
       </WrappedApp>,
     );
 
-    expect(container.textContent).toEqual('true');
+    expect(container.textContent).toEqual('10');
   });
 });

--- a/packages/feature-toggle-jsx/tests/withoutFeature.test.tsx
+++ b/packages/feature-toggle-jsx/tests/withoutFeature.test.tsx
@@ -2,13 +2,13 @@ import * as React from 'react';
 import { render, cleanup } from '@testing-library/react';
 import * as FeatureToggleJsx from '../src/index';
 
-type CustomFeatureFields = {
-  someCustomField: boolean,
-}
-
 type CustomFeatureConfig = {
-  feat1: FeatureToggleJsx.Feature & CustomFeatureFields
-  feat2: FeatureToggleJsx.Feature
+  someFeat: {
+    someCustomField: number,
+  },
+  anotherFeat: {
+    itsOver: number
+  }
 }
 
 const {
@@ -22,23 +22,19 @@ describe('withoutFeature', () => {
     jest.clearAllMocks();
   });
 
-  it('should only render wrapped component when feature is on', () => {
-    const featuresConfig: CustomFeatureConfig = {
-      feat1: {
-        isEnabled: true,
-        someCustomField: false
-      },
-      feat2: {
-        isEnabled: false
+  it('should only render wrapped component when feature is off', () => {
+    const featuresConfig = {
+      someFeat: {
+        someCustomField: 10
       }
-    };
+    } as CustomFeatureConfig;
 
     const App: React.FC = ({ children }) => <div>{children}</div>;
     const Feat1: React.FC = () => <span>This is feature 1</span>;
     const Feat2: React.FC = () => <span>This is feature 2</span>;
 
-    const WrappedFeat1 = withoutFeature(Feat1, 'feat1');
-    const WrappedFeat2 = withoutFeature(Feat2, 'feat2');
+    const WrappedFeat1 = withoutFeature(Feat1, 'someFeat');
+    const WrappedFeat2 = withoutFeature(Feat2, 'anotherFeat');
 
     const UnderTest: React.FC = () => (
       <><WrappedFeat1 /><WrappedFeat2 /></>
@@ -56,22 +52,18 @@ describe('withoutFeature', () => {
   });
 
   it('should enable using custom selector from feature config', () => {
-    const featuresConfig: CustomFeatureConfig = {
-      feat1: {
-        isEnabled: false,
-        someCustomField: false
-      },
-      feat2: {
-        isEnabled: true
+    const featuresConfig = {
+      someFeat: {
+        someCustomField: 10
       }
-    };
+    } as CustomFeatureConfig;
 
     const App: React.FC = ({ children }) => <div>{children}</div>;
     const Feat1: React.FC = () => <span>This is feature 1</span>;
     const Feat2: React.FC = () => <span>This is feature 2</span>;
 
-    const WrappedFeat1 = withoutFeature(Feat1, 'feat1', (_) => _.someCustomField);
-    const WrappedFeat2 = withoutFeature(Feat2, 'feat2');
+    const WrappedFeat1 = withoutFeature(Feat1, 'someFeat', (_) => _.someCustomField !== 10);
+    const WrappedFeat2 = withoutFeature(Feat2, 'someFeat');
 
     const UnderTest: React.FC = () => (
       <><WrappedFeat1 /><WrappedFeat2 /></>


### PR DESCRIPTION
FeatureConfig type refactor, to make it more generic - removing required isEnabled field from the
feature, now enabled/disabled state is computed based on presense/absense of feature object in the
config