### PR TITLE
fix(i18n-jsx): change default fallback variant to A

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -17,8 +17,8 @@
       "maxSize": "1 kB"
     },
     {
-      "path": "./packages/ab-test-jsx/lib/abtestjsx.umd.js",
-      "maxSize": "710 B"
+      "path": "./packages/i18n-jsx/lib/i18njsx.umd.js",
+      "maxSize": "1.6 kB"
     },
     {
       "path": "./packages/some-handy-hooks/lib/somehandyhooks.umd.js",

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "./packages/ab-test-jsx/lib/abtestjsx.umd.js",
-      "maxSize": "720 B"
+      "maxSize": "770 B"
     },
     {
       "path": "./packages/error-boundary-jsx/lib/errorboundaryjsx.umd.js",

--- a/packages/ab-test-jsx/README.md
+++ b/packages/ab-test-jsx/README.md
@@ -34,6 +34,12 @@ The app should be wrapped at the root level. Pass the ab tests allocation result
 </ABTestsProvider>
 ```
 
+Additional settings can be passed:
+
+```
+defaultVariant: 'A' // what variant should be returned if experiment cannot be found in the context. Defaults to A
+```
+
 ## `withABTestsProvider` Higher Order Component
 
 Wrap export of application root with the HOC and pass the ab tests allocation results object using param:

--- a/packages/ab-test-jsx/src/ABTestsContext/ABTestsContext.tsx
+++ b/packages/ab-test-jsx/src/ABTestsContext/ABTestsContext.tsx
@@ -2,4 +2,9 @@ import * as React from 'react';
 
 const ABTestsContext = React.createContext({});
 
+export type Settings = {
+  defaultVariant: string;
+}
+export const ABTestsSettings = React.createContext<Settings>({ defaultVariant: 'A' });
+
 export default ABTestsContext;

--- a/packages/ab-test-jsx/src/ABTestsProvider/ABTestsProvider.tsx
+++ b/packages/ab-test-jsx/src/ABTestsProvider/ABTestsProvider.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import ABTestsContext, { ABTests } from '../ABTestsContext';
+import { ABTestsSettings } from '../ABTestsContext/ABTestsContext';
 
 interface OwnProps<T> {
   abTests: T
+  defaultVariant?: 'A' | 'B' | 'Z'
 }
 
 type Props<T> = React.PropsWithChildren<OwnProps<T>>
@@ -10,10 +12,16 @@ type Props<T> = React.PropsWithChildren<OwnProps<T>>
 export type ABTestProviderComponent<T extends ABTests> = React.FC<Props<T>>
 
 const ABTestsProvider = React.memo(<T extends ABTests>(props: Props<T>) => {
-  const { abTests, children } = props;
-  return <ABTestsContext.Provider value={abTests}>{children}</ABTestsContext.Provider>;
+  const { abTests, children, defaultVariant = 'A' } = props;
+  return (
+    <ABTestsContext.Provider value={abTests}>
+      <ABTestsSettings.Provider value={{ defaultVariant }}>
+        {children}
+      </ABTestsSettings.Provider>
+    </ABTestsContext.Provider>
+  );
 });
 
-ABTestsContext.displayName = 'ABTestsContext';
+ABTestsContext.displayName = 'ABTestsProvider';
 
 export default ABTestsProvider;

--- a/packages/ab-test-jsx/src/useABTests/useABTests.tsx
+++ b/packages/ab-test-jsx/src/useABTests/useABTests.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import ABTestsContext, { ABTests } from '../ABTestsContext';
+import { ABTestsSettings } from '../ABTestsContext/ABTestsContext';
 
 export type useABTestsHook<T extends ABTests> = <TName extends Extract<keyof T, string | number>>() => {
   getVariant: (name: TName) => 'A' | 'B' | 'Z'
@@ -9,8 +10,9 @@ export type useABTestsHook<T extends ABTests> = <TName extends Extract<keyof T, 
 
 const useABTests = <T extends ABTests, TName extends Extract<keyof T, string | number>>() => {
   const abTests = React.useContext(ABTestsContext) as T;
+  const settings = React.useContext(ABTestsSettings);
 
-  const getVariant = (name: TName): 'A' | 'B' | 'Z' => abTests[name] || 'Z';
+  const getVariant = (name: TName): 'A' | 'B' | 'Z' => abTests[name] || settings.defaultVariant;
   const isB = (name: TName) => getVariant(name) === 'B';
   const isA = (name: TName) => getVariant(name) === 'A';
 

--- a/packages/ab-test-jsx/src/withABTestsProvider/withABTestsProvider.tsx
+++ b/packages/ab-test-jsx/src/withABTestsProvider/withABTestsProvider.tsx
@@ -6,7 +6,8 @@ import { nameOf } from '../react-utils';
 
 export type withABTestsProviderHoC<T extends ABTests> = <TProps extends {}>(
   Component: React.ComponentType<TProps>,
-  abTests: T | ABTestsSetter<TProps, T>
+  abTests: T | ABTestsSetter<TProps, T>,
+  defaultVariant?: 'A' | 'B' | 'Z'
 ) => React.FunctionComponent<TProps>
 
 type ABTestsSetter<TProps extends {}, T> = (componentProps: TProps) => T
@@ -14,11 +15,12 @@ type ABTestsSetter<TProps extends {}, T> = (componentProps: TProps) => T
 const withABTestsProvider = <T extends ABTests, TProps extends {}>(
   Component: React.ComponentType<TProps>,
   abTests: ABTestsSetter<TProps, T> | T,
+  defaultVariant?: 'A' | 'B' | 'Z'
 ) => {
   const Wrapped: React.FC<TProps> = React.memo((props) => {
     const values = typeof abTests === 'function' ? abTests(props) : abTests;
     return (
-      <ABTestsProvider abTests={values}>
+      <ABTestsProvider abTests={values} defaultVariant={defaultVariant}>
         <Component {...props} />
       </ABTestsProvider>
     );

--- a/packages/ab-test-jsx/tests/ABTest.test.tsx
+++ b/packages/ab-test-jsx/tests/ABTest.test.tsx
@@ -99,6 +99,34 @@ describe('ABTest', () => {
     expect(container.textContent).toEqual('test1=A,test2=B');
   });
 
+  it('should render A variant if experiment cannot be evaluated (A default)', () => {
+    const abTests: Tests = {
+      test1: 'A',
+      test2: 'B'
+    };
+
+    const UnderTest: React.FC = () => (
+      <>
+        <ABTest name="test1" variant="A">
+          <span>test1=A</span>
+        </ABTest>
+        <ABTestJsx.ABTest name="test3" variant="A">
+          <span>test3(not-allocated)=A</span>
+        </ABTestJsx.ABTest>
+        <ABTestJsx.ABTest name="test3" variant="B">
+          <span>test3(not-allocated)=B</span>
+        </ABTestJsx.ABTest>
+      </>
+    );
+
+    const { container } = render(
+      <ABTestsProvider abTests={abTests}>
+        <UnderTest />
+      </ABTestsProvider>,
+    );
+
+    expect(container.textContent).toEqual('test1=Atest3(not-allocated)=A');
+  });
   it('should not render A nor B variant if experiment cannot be evaluated (Z)', () => {
     const abTests: Tests = {
       test1: 'A',
@@ -120,7 +148,7 @@ describe('ABTest', () => {
     );
 
     const { container } = render(
-      <ABTestsProvider abTests={abTests}>
+      <ABTestsProvider abTests={abTests} defaultVariant="Z">
         <UnderTest />
       </ABTestsProvider>,
     );

--- a/packages/ab-test-jsx/tests/useABTests.test.tsx
+++ b/packages/ab-test-jsx/tests/useABTests.test.tsx
@@ -155,7 +155,7 @@ describe('useABTests', () => {
     expect(container.textContent).toEqual('isA:false');
   });
 
-  it('isA should return false if test is Z', () => {
+  it('isA should return true if test is Z', () => {
     const abTests: Tests = {
       test1: 'A',
       test2: 'B'
@@ -172,10 +172,10 @@ describe('useABTests', () => {
       </ABTestsProvider>,
     );
 
-    expect(container.textContent).toEqual('isA:false');
+    expect(container.textContent).toEqual('isA:true');
   });
 
-  it('getVariant should return Z when experiment is not allocated in context', () => {
+  it('getVariant should return A when experiment is not allocated in context', () => {
     const abTests: Tests = {
       test1: 'A',
       test2: 'B'
@@ -188,6 +188,26 @@ describe('useABTests', () => {
 
     const { container } = render(
       <ABTestsProvider abTests={abTests}>
+        <UnderTest />
+      </ABTestsProvider>,
+    );
+
+    expect(container.textContent).toEqual('getVariant:A');
+  });
+
+  it('getVariant should return Z when experiment is not allocated in context and Z is default', () => {
+    const abTests: Tests = {
+      test1: 'A',
+      test2: 'B'
+    };
+
+    const UnderTest: React.FC = () => {
+      const { getVariant } = ABTestJsx.useABTests();
+      return <span>getVariant:{getVariant('test3')}</span>;
+    };
+
+    const { container } = render(
+      <ABTestsProvider abTests={abTests} defaultVariant="Z">
         <UnderTest />
       </ABTestsProvider>,
     );


### PR DESCRIPTION
Change default fallback variant for case when experiment cannot be allocated to A. Value can be
modified by passing a defaultVariant setting to the context provider.

BREAKING CHANGE: Default behavour of miss-allocation is different: A variant is used instead of Z