### PR TITLE
fix: typo on feature-toggle-jsx/README.md

### DIFF
--- a/packages/feature-toggle-jsx/README.md
+++ b/packages/feature-toggle-jsx/README.md
@@ -34,7 +34,7 @@ export default withFeature(ChatComponent, "chat")
 import { withFeature } from "feature-toggle-jsx"
 const ImagePreviewComponent = ({ props, perPage }) => {...}
 
-export default withFeature(ImagePreviewComponent, "preview", _ =_.perPage == 2) // will only render if feature perPage value meets the selector criteria.
+export default withFeature(ImagePreviewComponent, "preview", _ => _.perPage == 2) // will only render if feature perPage value meets the selector criteria.
 ```
 
 ```jsx


### PR DESCRIPTION
I think the third argument in `withFeature()` should be a function but the current doc writes it as `_ =_.perPage == 2`. It should be an arrow function `_ => _.perPage == 2`